### PR TITLE
use jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![GitHub issues](https://img.shields.io/github/issues/dituon/petpet)
 ![GitHub closed issues](https://img.shields.io/github/issues-closed/dituon/petpet)
 ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/dituon/petpet)
+[![](https://jitpack.io/v/Dituon/petpet.svg)](https://jitpack.io/#Dituon/petpet)
 
 一个生成摸摸头GIF的 Mirai 插件，灵感/数据来自 [nonebot-plugin-petpet](https://github.com/noneplugin/nonebot-plugin-petpet)。
 
@@ -210,6 +211,11 @@ content:
 ## 分享你的作品
 
 如果你想分享自定义的 Petpet, **欢迎Pr**
+
+## 依赖share包二次开发
+
+- 方式1. 在本项目内二次开发（非mirai插件形式）：见`xmmt.dituon.example.SimpleUsage`
+- 方式2. 在别的项目二次开发：通过jitpack获得依赖（待补充样例）
 
 ## 后话
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,11 @@ plugins {
     id 'net.mamoe.mirai-console' version '2.11.0'
 }
 
+apply plugin: "maven-publish"
+apply plugin: "java"
+
+
+
 group = 'xmmt.dituon'
 version = '2.4'
 
@@ -15,4 +20,30 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier.set("sources")
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives sourcesJar
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            // useless for jitpack: groupId = GROUP
+            artifactId = "petpet-share"
+            // useless for jitpack: version = VERSION
+
+            from components.java
+        }
+    }
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
petpet插件随着新增功能越来越不适合初学者入门二次开发，但是初学者可以依赖share包二次开发简单版本的mirai插件