### PR TITLE
fix(Plugin): allow response to images sent by other Onebot clients when using Overflow with LLonebot

### DIFF
--- a/src/main/java/moe/dituon/petpet/mirai/MiraiPetpet.java
+++ b/src/main/java/moe/dituon/petpet/mirai/MiraiPetpet.java
@@ -101,6 +101,7 @@ public final class MiraiPetpet extends JavaPlugin {
             };
             GlobalEventChannel.INSTANCE.subscribeAlways(GroupMessageEvent.class, this::cacheMessageImage);
             GlobalEventChannel.INSTANCE.subscribeAlways(GroupMessagePostSendEvent.class, this::cacheMessageImage);
+            GlobalEventChannel.INSTANCE.subscribeAlways(GroupMessageSyncEvent.class, this::cacheMessageImage);
 
             if (service.respondFriend) {
                 GlobalEventChannel.INSTANCE.subscribeAlways(UserMessageEvent.class, this::cacheMessageImage);


### PR DESCRIPTION
[Overflow 项目](https://github.com/MrXiaoM/Overflow/blob/cf8fec72ca8bfc9cd5535a7aefea573c859cd8e8/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/listener/group.kt#L63-L74) 中关于自己发送的消息会广播为 GroupMessageSyncEvent 事件而非 GroupMessageEvent 事件。通过监听 GroupMessageSyncEvent 事件，使得 petpet 项目可以正确处理并响应来自其他 Onebot 客户端发送的图片。
```kotlin
if (member.id == bot.id) {
    bot.logger.verbose("[SYNC] [${group.name}(${group.id})] <- $messageString")
    @Suppress("DEPRECATION") // TODO: 无法获取到哪个客户端发送的消息
    bot.eventDispatcher.broadcastAsync(GroupMessageSyncEvent(
        group, miraiMessage, member, member.nameCardOrNick, messageSource.time
    ))
} else {
    bot.logger.verbose("[${group.name}(${group.id})] ${member.nameCardOrNick}(${member.id}) -> $messageString")
    bot.eventDispatcher.broadcastAsync(GroupMessageEvent(
        member.nameCardOrNick, member.permission, member, miraiMessage, messageSource.time
    ))
}
```