### PR TITLE
fix(Bot): 修复 OnebotMessageChainWrapper 空指针问题

### DIFF
--- a/bot/onebot/src/main/kotlin/moe/dituon/petpet/bot/qq/onebot/handler/OnebotMessageChainWrapper.kt
+++ b/bot/onebot/src/main/kotlin/moe/dituon/petpet/bot/qq/onebot/handler/OnebotMessageChainWrapper.kt
@@ -75,7 +75,7 @@ open class OnebotMessageChainWrapper(
                     val atTarget = data[FIELD_QQ].asString
                     if (atTarget == AT_ALL) return@forEach
 
-                    if (!firstAtSenderRemoved && msgObj[FIELD_USER_ID].asString == atTarget) {
+                    if (!firstAtSenderRemoved && eventObject[FIELD_USER_ID].asString == atTarget) {
                         firstAtSenderRemoved = true
                         return@forEach
                     }


### PR DESCRIPTION
### 修改内容
在 OnebotMessageChainWrapper 的 TYPE_AT 分支中，原先使用 msgObj[FIELD_USER_ID].asString 判断是否第一次@发送者本人，导致空指针异常（NullPointerException）。这里应该使用的是eventObject[FIELD_USER_ID]，
修改为使用 eventObject[FIELD_USER_ID].asString，以确保取到正确的用户 ID，避免空指针。
### Json格式样例
```Json
{
    "self_id": 111,
    "user_id": 111,
    "time": 111,
    "message_id": 111,
    "message_seq": 111,
    "real_id": 111,
    "message_type": "group",
    "sender": { "user_id": 111, "nickname": "AAA", "card": "AAA", "role": "member" },
    "raw_message": "...",
    "font": 14,
    "sub_type": "normal",
    "message": [
      { "type": "at", "data": { "qq": "111" } },
      { "type": "text", "data": { "text": "..." } }
    ],
    "message_format": "array",
    "post_type": "message",
    "group_id": 111
}
```
user_id与message_id是同级元素，而非msgObj的成员