### PR TITLE
feat(Bot): 修复戳一戳目标错误 & 对特殊情况进行处理

### DIFF
--- a/bot/shared/src/main/java/moe/dituon/petpet/bot/qq/handler/QQNudgeEventHandler.java
+++ b/bot/shared/src/main/java/moe/dituon/petpet/bot/qq/handler/QQNudgeEventHandler.java
@@ -38,10 +38,22 @@ public class QQNudgeEventHandler extends QQMessageEventHandler {
 
         @Override
         protected RequestContext buildRequestContext() {
-            List<QQMessageElement.ResizeableImageElement> imageList = List.of(
-                    QQMessageElement.AtElement.from(getTargetId(), getTargetName()), // Target
-                    QQMessageElement.AtElement.from(getSenderId(), getSenderName()) // Sender
-            );
+            List<QQMessageElement.ResizeableImageElement> imageList;
+            String BotId = getBotId();
+            String SenderId = getSenderId();
+            String TargetId = getTargetId();
+            if (BotId.equals(TargetId) || SenderId.equals(TargetId)){
+                //特殊情况：戳Bot或戳自己
+                imageList = List.of(
+                        QQMessageElement.AtElement.from(getBotId(), getBotName()), // Sender
+                        QQMessageElement.AtElement.from(getSenderId(), getSenderName())  // Target
+                );
+            } else {
+                imageList = List.of(
+                        QQMessageElement.AtElement.from(getSenderId(), getSenderName()), // Sender
+                        QQMessageElement.AtElement.from(getTargetId(), getTargetName())  // Target
+                );
+            }
 
             // 构建 imageUrlMap 和 textMap
             return buildRequestContext(imageList);


### PR DESCRIPTION
## 修复内容
之前戳一戳的From和To反了
`buildImageUrlMap`中的顺序是：
``` Java
case FROM_KEY:
    return finalImageList.get(finalImageList.size() - 2).getUrl(getAvatarSize(key));
case TO_KEY:
    return finalImageList.get(finalImageList.size() - 1).getUrl(getAvatarSize(key));
```
但是（之前错误的）戳一戳的buildRequestContext中的顺序是先Target后Sender。

## 增加特性

### 在戳一戳的目标是Bot时，使用Bot作为From，用户作为To。
理由：我觉得应该没人会对制造Bot的表情图感兴趣吧（
此外，旧版本PetPet在Bot被戳时特性就是如此。
### 在戳一戳的From和To相同时（自己戳自己），使用Bot作为From，用户作为To。
理由：在双人互动表情时与文字指令的模式保持一致。例如我如果直接使用 `撅@我自己`，文字指令生成的图片就是Bot撅我自己，而不是我 自己撅自己。那么我戳Bot时表现也应该一致才符合自觉。
而且戳出 自己撅自己 这样的表情包也很反直觉。如果真的需要生成这种表情，可以使用 `撅 @自己 @自己`
此外，旧版本PetPet在Bot被戳时特性就是如此。

文字指令触发时（以及旧版本PetPet）会有这种表现的原因是`buildRequestContext()`方法为了确保 imageList 至少有两个元素会自动追加Sender与Bot元素，而戳一戳默认就一定有From和To两个元素，因此需要手动判断这种特殊情况来让两种方法的行为统一。