### PR TITLE
fix(Bot): 修复 Overflow 空转发信息问题

### DIFF
--- a/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/ScriptMiraiBotSendEvent.java
+++ b/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/ScriptMiraiBotSendEvent.java
@@ -4,7 +4,6 @@ import moe.dituon.petpet.bot.BotSendEvent;
 import moe.dituon.petpet.core.context.RequestContext;
 import moe.dituon.petpet.core.utils.image.EncodedImage;
 import net.mamoe.mirai.Bot;
-import net.mamoe.mirai.event.events.MessageEvent;
 import net.mamoe.mirai.message.data.ForwardMessageBuilder;
 import net.mamoe.mirai.message.data.MessageChain;
 import net.mamoe.mirai.message.data.MessageChainBuilder;
@@ -73,8 +72,10 @@ public class ScriptMiraiBotSendEvent extends BotSendEvent {
         if (isResponseInForward) {
             var fb = new ForwardMessageBuilder(bot.getAsFriend(), messageBuilderList.size());
             for (MessageChainBuilder mb : messageBuilderList) {
-                if (mb.isEmpty()) continue;
-                fb.add(bot, mb.build());
+                try {
+                    fb.add(bot, mb.build());
+                } catch (Exception ignored) {
+                }
             }
             return List.of(new MessageChainBuilder(1).append(fb.build()).build());
         }


### PR DESCRIPTION
https://github.com/Dituon/petpet/blob/66984eb504719e5e545753b0b02e3fda3a5fcb28/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/ScriptMiraiBotSendEvent.java#L69-L86

将上述代码改为

```
    /**
     * 当回复转发消息时, 数组仅包含一个转发消息元素; 当回复普通消息时, 数组可能包含多个元素
     */
    public List<MessageChain> getResponseMessage() {
        if (isResponseInForward) {
            MessageChainBuilder mcb = messageBuilderList.get(0);
            System.out.println(mcb.isEmpty());
            mcb.build();
            System.out.println(mcb.isEmpty());
            var fb = new ForwardMessageBuilder(bot.getAsFriend(), messageBuilderList.size());
            for (MessageChainBuilder mb : messageBuilderList) {
                if (mb.isEmpty()) continue;
                fb.add(bot, mb.build());
            }
            return List.of(new MessageChainBuilder(1).append(fb.build()).build());
        }
```

控制台输出为：
```
2025-03-07 10:20:48 V/Bot.: [TEST()] username() -> pet
2025-03-07 10:20:48 I/stdout: true
2025-03-07 10:20:48 I/stdout: false
```

可见在`Overflow`上，`mb.isEmpty()`方法在`MessageChainBuilder`实际`build()`之前都是`true`

因此可以直接改为`try catch`结构？

实测改后转发信息已恢复正常

![image](https://github.com/user-attachments/assets/862f36e6-8740-4ffe-95e4-79fafbeccc92)

Close #131
