### PR TITLE
fix(Bot): 修复Overflow中无法正常获取replyImage的问题

### DIFF
--- a/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/MiraiBotService.java
+++ b/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/MiraiBotService.java
@@ -60,6 +60,11 @@ public class MiraiBotService extends QQBotService {
         return this.getImageCachePool().get(id);
     }
 
+    public @Nullable String getCachedImage(MessageSource source, Long targetId) {
+        long id = getUniqueSourceId(source, targetId);
+        return this.getImageCachePool().get(id);
+    }
+
     /**
      * 计算消息唯一 id, 如果无法获取消息 id (低概率事件) 则返回 0
      */
@@ -75,6 +80,17 @@ public class MiraiBotService extends QQBotService {
         return source.getTargetId() + sourceIds[0];
     }
 
+    public long getUniqueSourceId(@Nullable MessageSource source, Long targetId) {
+        if (source == null) {
+            return 0L;
+        }
+        int[] sourceIds = source.getIds();
+        if (sourceIds.length == 0) {
+            return 0L;
+        }
+        // message id = target id + source id
+        return targetId + sourceIds[0];
+    }
 
     @Override
     protected Map<String, TemplateExtraMetadata> initCustomTemplateMetadata() {

--- a/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/handler/MiraiMessageChainWrapper.java
+++ b/bot/mirai/src/main/java/moe/dituon/petpet/bot/qq/mirai/handler/MiraiMessageChainWrapper.java
@@ -59,7 +59,11 @@ public class MiraiMessageChainWrapper implements QQMessageChainInterface {
                 this.elements.add(wrapAtElement(at));
                 this.hasTarget = true;
             } else if (ele instanceof QuoteReply) {
-                this.replyImage = service.getCachedImage(((QuoteReply) ele).getSource());
+                if(source != null) {
+                    this.replyImage = service.getCachedImage(((QuoteReply) ele).getSource(), source.getTargetId());
+                } else {
+                    this.replyImage = service.getCachedImage(((QuoteReply) ele).getSource());
+                }
                 this.hasTarget = true;
             }
         }


### PR DESCRIPTION
## Overflow中存在QuotaReply中TargetId为0的情况
如图所示，回复图片petpet出现的依然是发送人的头像
<img width="693" height="696" alt="image" src="https://github.com/user-attachments/assets/ba1dff4f-cbd8-4178-afb8-c85ab4e026b7" />
日志大致如下（Stdout为Petpet内部获取缓存图片的ID和MessageSource类）：
```
2025-08-04 17:14:12 V/Bot.【BotId】: [测试(【GroupId】)] 【NickName】(【UserId】) -> [overflow:image,url=https://IMAGEURL]
2025-08-04 17:14:12 I/stdout: [SourceId]1313310701
2025-08-04 17:14:12 I/stdout: [mirai:source:ids=[294953152], internalIds=[294953152], from group 【UserId】 to 【GroupId】 at 1754****52]
2025-08-04 17:14:15 V/Bot.【BotId】: [测试(【GroupId】)] 【NickName】(【UserId】) -> [mirai:quote:[mirai:source:ids=[294953152], internalIds=[294953152], from 【UserId】 to 0 at 1754****52], content=[overflow:image,url=https://IMAGEURL]]333
2025-08-04 17:14:15 I/stdout: [SourceId]294***152
2025-08-04 17:14:15 I/stdout: [mirai:source:ids=[294953152], internalIds=[294953152], from 【UserId】 to 0 at 1754****52]
```

可以看到GroupId在MessageSource变成了0

## 解决方案
提供一个TargetID给函数可以解决（因为我们可以无脑将QuotaReply视作在一个Target下），恢复正常：
<img width="594" height="648" alt="image" src="https://github.com/user-attachments/assets/fe35760e-c0be-4649-9c17-24539b276bf8" />


或者看看有没有更优雅点的？
